### PR TITLE
Added FanStateGet

### DIFF
--- a/Drivers/GoControl GC-TBZ48/GoControl GC-TBZ48.groovy
+++ b/Drivers/GoControl GC-TBZ48/GoControl GC-TBZ48.groovy
@@ -232,7 +232,8 @@ def fanOn() {
 	if (logEnable) log.debug "Switching fan to on mode..."
     return delayBetween([
 		zwave.thermostatFanModeV1.thermostatFanModeSet(fanMode: 1).format(),
-		zwave.thermostatFanModeV1.thermostatFanModeGet().format()
+		zwave.thermostatFanModeV1.thermostatFanModeGet().format(),
+		zwave.thermostatFanStateV1.thermostatFanStateGet().format()
 	], 1000)   
 }
 
@@ -240,7 +241,8 @@ def fanAuto() {
 	if (logEnable) log.debug "Switching fan to auto mode..."
     return delayBetween([
 		zwave.thermostatFanModeV1.thermostatFanModeSet(fanMode: 0).format(),
-		zwave.thermostatFanModeV1.thermostatFanModeGet().format()
+		zwave.thermostatFanModeV1.thermostatFanModeGet().format(),
+		zwave.thermostatFanStateV1.thermostatFanStateGet().format()
 	], 1000)
 }
 
@@ -275,6 +277,7 @@ def setThermostatFanMode(value) {
 			break
 	}
 	cmds << zwave.thermostatFanModeV1.thermostatFanModeGet().format()
+	cmds << zwave.thermostatFanStateV1.thermostatFanStateGet().format()
 	return delayBetween(cmds, 1000)
 }
 


### PR DESCRIPTION
Fan state did not update once when mode changed so added this for extra protection.

This is REALLY getting into the finer details...but I thought I would pass it along.  I was playing around with an app I was writing to automatically control my ceiling fans based on my thermostat.  I was basing it off thermostatOperatinigState but then I noticed that your enhanced driver also has the custom attribute thermostatFanState. So, I thought I could make my app a lot simpler by using that instead. So, I go to try my app and change the fan from auto to on and it worked.  But the first time I changed it from on to auto the thermostatFanState never updated from running back to idle, even though the fan had stopped.  I waited about a minute and I even tried changing the operating mode to off but it never updated the fan state until I turned it back to Heat mode.  I was a little confused by this.  So, when I looked in the driver, it seemed pretty simple what had to change.  To make sure it was working, I ran both versions through a bunch of different commands with debug logging turned on and, of course, couldn't get the problem to reproduce itself.  😠 So, these changes might be completely unnecessary and it might work 99.9999% of time time but it happened to me so I figured I'd pass it along, just in case.  

I didn't have debug logging turned on when it happened but I went back and grabbed the events, just to make sure I wasn't going crazy(er) and it was there. 
![image](https://user-images.githubusercontent.com/30270489/71325404-38949500-24ba-11ea-94b1-962b1722dfbc.png)

Thanks again!