### PR TITLE
Update GE-Jasco Z-Wave Plus Motion Switch.groovy

### DIFF
--- a/Drivers/GE-Jasco Z-Wave Plus Motion Switch/GE-Jasco Z-Wave Plus Motion Switch.groovy
+++ b/Drivers/GE-Jasco Z-Wave Plus Motion Switch/GE-Jasco Z-Wave Plus Motion Switch.groovy
@@ -421,7 +421,7 @@ def updated() {
 	if (paramMotionResetTimer==null) {
 		paramMotionResetTimer = 2
 	}
-	cmds << zwave.configurationV2.configurationSet(scaledConfigurationValue: paramMotionResetTimer.toInteger(), parameterNumber: 15, size: 1).format()
+	cmds << zwave.configurationV2.configurationSet(scaledConfigurationValue: paramMotionResetTimer.toInteger(), parameterNumber: 15, size: 2).format()
 	cmds << zwave.configurationV2.configurationGet(parameterNumber: 15).format()
 
     // Association groups


### PR DESCRIPTION
Same issue reported and fixed in the Component Driver: Motion Reset Timer was not saving properly.